### PR TITLE
Made the either's Action Match throw null for unspecified parameters …

### DIFF
--- a/src/NCommons.Tests/Monads/EitherTests.cs
+++ b/src/NCommons.Tests/Monads/EitherTests.cs
@@ -86,42 +86,13 @@ namespace NCommons.Monads.Tests
         #region Either.Match()
 
         [Fact]
-        public void Action_Match_Accepts_Null()
+        public void Action_Match_Throws_For_Null()
         {
+#nullable disable
             var either = new Either<Left, Right>();
-            either.Match(null, null); // Should not throw.
-        }
-
-        [Fact]
-        public void Action_Match_Ignores_Left_Action_If_Null()
-        {
-            var either = new Either<Left, Right>(new Left());
-            either.Match(null, r => throw new Exception("Should not be called."));
-        }
-
-        [Fact]
-        public void Action_Match_Ignores_Right_Action_If_Null()
-        {
-            var either = new Either<Left, Right>(new Right());
-            either.Match(l => throw new Exception("Should not be called."), null);
-        }
-
-        [Fact]
-        public void Action_Match_Calls_Left_Action_Even_If_Right_Action_Is_Null()
-        {
-            bool wasLeftCalled = false;
-            var either = new Either<Left, Right>(new Left());
-            either.Match(l => { wasLeftCalled = true; }, null);
-            Assert.True(wasLeftCalled);
-        }
-        
-        [Fact]
-        public void Action_Match_Calls_Right_Action_Even_If_Left_Action_Is_Null()
-        {
-            bool wasRightCalled = false;
-            var either = new Either<Left, Right>(new Right());
-            either.Match(null, r => { wasRightCalled = true; });
-            Assert.True(wasRightCalled);
+            Assert.Throws<ArgumentNullException>(() => either.Match(null, r => { }));
+            Assert.Throws<ArgumentNullException>(() => either.Match(l => { }, null));
+#nullable enable
         }
 
         [Fact]
@@ -367,21 +338,21 @@ namespace NCommons.Monads.Tests
         public void LeftOrThrow_Throws_For_Right_Either()
         {
             var either = new Either<Left, Right>(new Right());
-            Assert.Throws<UnmatchedEitherTypeException>(() => either.LeftOrThrow());
+            Assert.Throws<UnexpectedEitherTypeException>(() => either.LeftOrThrow());
         }
         
         [Fact]
         public void RightOrThrow_Throws_For_Left_Either()
         {
             var either = new Either<Left, Right>(new Left());
-            Assert.Throws<UnmatchedEitherTypeException>(() => either.RightOrThrow());
+            Assert.Throws<UnexpectedEitherTypeException>(() => either.RightOrThrow());
         }
 
         [Fact]
         public void LeftOrThrow_Throws_Exception_With_Correct_ActualType()
         {
             var either = new Either<Left, Right>(new Right());
-            var ex = (UnmatchedEitherTypeException)Record.Exception(() => either.LeftOrThrow());
+            var ex = (UnexpectedEitherTypeException)Record.Exception(() => either.LeftOrThrow());
             Assert.Equal(EitherType.Right, ex.ActualType);
         }
 
@@ -389,7 +360,7 @@ namespace NCommons.Monads.Tests
         public void RightOrThrow_Throws_Exception_With_Correct_ActualType()
         {
             var either = new Either<Left, Right>(new Left());
-            var ex = (UnmatchedEitherTypeException)Record.Exception(() => either.RightOrThrow());
+            var ex = (UnexpectedEitherTypeException)Record.Exception(() => either.RightOrThrow());
             Assert.Equal(EitherType.Left, ex.ActualType);
         }
 

--- a/src/NCommons/Monads/Either.cs
+++ b/src/NCommons/Monads/Either.cs
@@ -117,29 +117,34 @@ namespace NCommons.Monads
 
         /// <summary>
         ///     Matches the two specified functions to the either's <see cref="Type"/> and executes
-        ///     the matching function, if present.
+        ///     the matching function.
         /// </summary>
         /// <param name="onLeft">
         ///     A function to be executed if the either holds a left value.
         ///     The function receives the left value as a parameter.
-        ///     Can be <c>null</c>. If <c>null</c>, nothing will happen if the either holds a left
-        ///     value.
         /// </param>
         /// <param name="onRight">
         ///     A function to be executed if the either holds a right value.
         ///     The function receives the right value as a parameter.
-        ///     Can be <c>null</c>. If <c>null</c>, nothing will happen if the either holds a right
-        ///     value.
         /// </param>
-        public void Match(Action<TL>? onLeft = null, Action<TR>? onRight = null)
+        /// <exception cref="ArgumentNullException">
+        ///     * <paramref name="onLeft"/>
+        ///     * <paramref name="onRight"/>
+        /// </exception>
+        public void Match(Action<TL> onLeft, Action<TR> onRight)
         {
+            if (onLeft is null)
+                throw new ArgumentNullException(nameof(onLeft));
+            if (onRight is null)
+                throw new ArgumentNullException(nameof(onRight));
+
             if (IsLeft)
             {
-                onLeft?.Invoke(_left);
+                onLeft(_left);
             }
             else
             {
-                onRight?.Invoke(_right);
+                onRight(_right);
             }
         }
 
@@ -266,28 +271,28 @@ namespace NCommons.Monads
 
         /// <summary>
         ///     Returns the either's left value if it holds one.
-        ///     Otherwise, an <see cref="UnmatchedEitherTypeException"/> is thrown.
+        ///     Otherwise, an <see cref="UnexpectedEitherTypeException"/> is thrown.
         /// </summary>
         /// <returns>The either's left value.</returns>
-        /// <exception cref="UnmatchedEitherTypeException">
+        /// <exception cref="UnexpectedEitherTypeException">
         ///     Thrown if the either holds a right value.
         /// </exception>
         public TL LeftOrThrow()
         {
-            return IsLeft ? _left : throw new UnmatchedEitherTypeException(Type);
+            return IsLeft ? _left : throw new UnexpectedEitherTypeException(Type);
         }
 
         /// <summary>
         ///     Returns the either's right value if it holds one.
-        ///     Otherwise, an <see cref="UnmatchedEitherTypeException"/> is thrown.
+        ///     Otherwise, an <see cref="UnexpectedEitherTypeException"/> is thrown.
         /// </summary>
         /// <returns>The either's right value.</returns>
-        /// <exception cref="UnmatchedEitherTypeException">
+        /// <exception cref="UnexpectedEitherTypeException">
         ///     Thrown if the either holds a left value.
         /// </exception>
         public TR RightOrThrow()
         {
-            return IsRight ? _right : throw new UnmatchedEitherTypeException(Type);
+            return IsRight ? _right : throw new UnexpectedEitherTypeException(Type);
         }
 
         /// <summary>

--- a/src/NCommons/Monads/Resources/ExceptionStrings.Designer.cs
+++ b/src/NCommons/Monads/Resources/ExceptionStrings.Designer.cs
@@ -61,11 +61,11 @@ namespace NCommons.Monads.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to An attempt was made to read the &quot;{0}&quot; value of an either. The either does, however, hold a &quot;{1}&quot; value..
+        ///   Looks up a localized string similar to An attempt was made to read the value of an either of type &quot;{0}&quot;. The either is, however, of type &quot;{1}&quot;..
         /// </summary>
-        internal static string UnmatchedEitherTypeException_DefaultMessage {
+        internal static string UnexpectedEitherTypeException_DefaultMessage {
             get {
-                return ResourceManager.GetString("UnmatchedEitherTypeException_DefaultMessage", resourceCulture);
+                return ResourceManager.GetString("UnexpectedEitherTypeException_DefaultMessage", resourceCulture);
             }
         }
     }

--- a/src/NCommons/Monads/Resources/ExceptionStrings.resx
+++ b/src/NCommons/Monads/Resources/ExceptionStrings.resx
@@ -117,8 +117,8 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="UnmatchedEitherTypeException_DefaultMessage" xml:space="preserve">
-    <value>An attempt was made to read the "{0}" value of an either. The either does, however, hold a "{1}" value.</value>
+  <data name="UnexpectedEitherTypeException_DefaultMessage" xml:space="preserve">
+    <value>An attempt was made to read the value of an either of type "{0}". The either is, however, of type "{1}".</value>
     <comment>{0} and {1} stand for Left/Right respectively.</comment>
   </data>
 </root>

--- a/src/NCommons/Monads/UnexpectedEitherTypeException.cs
+++ b/src/NCommons/Monads/UnexpectedEitherTypeException.cs
@@ -14,7 +14,7 @@ namespace NCommons.Monads
     ///     hold.
     /// </summary>
     [Serializable]
-    public class UnmatchedEitherTypeException : Exception
+    public class UnexpectedEitherTypeException : Exception
     {
 
         /// <summary>
@@ -24,40 +24,40 @@ namespace NCommons.Monads
         public EitherType ActualType { get; }
 
         /// <summary>
-        ///     Initializes a new instance of the <see cref="UnmatchedEitherTypeException"/>.
+        ///     Initializes a new instance of the <see cref="UnexpectedEitherTypeException"/>.
         /// </summary>
         /// <param name="actualType">The actual type of the either which was the cause of this exception.</param>
-        public UnmatchedEitherTypeException(EitherType actualType)
+        public UnexpectedEitherTypeException(EitherType actualType)
             : this(actualType, null) { }
 
         /// <summary>
-        ///     Initializes a new instance of the <see cref="UnmatchedEitherTypeException"/>.
+        ///     Initializes a new instance of the <see cref="UnexpectedEitherTypeException"/>.
         /// </summary>
         /// <param name="actualType">The actual type of the either which was the cause of this exception.</param>
         /// <param name="message">A message describing the error.</param>
-        public UnmatchedEitherTypeException(EitherType actualType, string? message) 
+        public UnexpectedEitherTypeException(EitherType actualType, string? message) 
             : this(actualType, message, null) { }
 
         /// <summary>
-        ///     Initializes a new instance of the <see cref="UnmatchedEitherTypeException"/>.
+        ///     Initializes a new instance of the <see cref="UnexpectedEitherTypeException"/>.
         /// </summary>
         /// <param name="actualType">The actual type of the either which was the cause of this exception.</param>
         /// <param name="message">A message describing the error.</param>
         /// <param name="innerException">An exception which was the cause of this exception.</param>
-        public UnmatchedEitherTypeException(EitherType actualType, string? message, Exception? innerException)
+        public UnexpectedEitherTypeException(EitherType actualType, string? message, Exception? innerException)
             : base(message ?? BuildMessage(actualType), innerException)
         {
             ActualType = actualType;
         }
 
-        protected UnmatchedEitherTypeException(SerializationInfo serializationInfo, StreamingContext streamingContext)
+        protected UnexpectedEitherTypeException(SerializationInfo serializationInfo, StreamingContext streamingContext)
             : base(serializationInfo, streamingContext) { }
 
         private static string BuildMessage(EitherType actualType)
         {
             return string.Format(
                 CultureInfo.InvariantCulture,
-                ExceptionStrings.UnmatchedEitherTypeException_DefaultMessage,
+                ExceptionStrings.UnexpectedEitherTypeException_DefaultMessage,
                 actualType.Invert().ToString(),
                 actualType.ToString()
             );

--- a/src/NCommons/NCommons.csproj
+++ b/src/NCommons/NCommons.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <Description>A reusable set of common members that are missing in the .NET Framework.</Description>
   </PropertyGroup>
 
@@ -13,10 +13,19 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>ExceptionStrings.resx</DependentUpon>
     </Compile>
+    <Compile Update="Monads\Resources\ExceptionStrings.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>ExceptionStrings.resx</DependentUpon>
+    </Compile>
   </ItemGroup>
 
   <ItemGroup>
     <EmbeddedResource Update="Monads/Resources/ExceptionStrings.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>ExceptionStrings.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="Monads\Resources\ExceptionStrings.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>ExceptionStrings.Designer.cs</LastGenOutput>
     </EmbeddedResource>


### PR DESCRIPTION
…again to be more consistent with the rest of the API.

Renamed UnmatchedEitherTypeException to UnexpectedEitherTypeException to better reflect the intent.
Updated tests accordingly.